### PR TITLE
feat: 画像添付とX(Twitter)同時投稿に対応

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "vrchat-group-notify-scheduler",
   "description": "VRChat Group Notify Scheduler Extension",
-  "version": "2.0.1",
+  "version": "2.1.0-rc.1",
   "author": "TakaAizu",
   "scripts": {
     "dev": "next dev",

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -36,6 +36,15 @@ export default function Dashboard() {
   const [recurrenceType, setRecurrenceType] = useState('daily');
   const [recurrenceDays, setRecurrenceDays] = useState([]);
 
+  // Image State
+  const [imageDataUrl, setImageDataUrl] = useState('');
+  const [imageName, setImageName] = useState('');
+
+  // X(Twitter) State
+  const [postToX, setPostToX] = useState(false);
+  const [xText, setXText] = useState('');
+  const [xLoggedIn, setXLoggedIn] = useState(null); // null = unknown, true/false = checked
+
   // Update State
   const [updateInfo, setUpdateInfo] = useState(null);
   const [showUpdateBanner, setShowUpdateBanner] = useState(false);
@@ -290,6 +299,39 @@ export default function Dashboard() {
     }
   };
 
+  const handleImageChange = (e) => {
+    const file = e.target.files?.[0];
+    if (!file) {
+      setImageDataUrl('');
+      setImageName('');
+      return;
+    }
+    const MAX_SIZE = 5 * 1024 * 1024;
+    if (file.size > MAX_SIZE) {
+      setError('画像サイズは5MB以下にしてください');
+      e.target.value = '';
+      return;
+    }
+    const reader = new FileReader();
+    reader.onload = () => {
+      setImageDataUrl(reader.result);
+      setImageName(file.name);
+    };
+    reader.onerror = () => setError('画像の読み込みに失敗しました');
+    reader.readAsDataURL(file);
+  };
+
+  const handleCheckXLogin = async () => {
+    try {
+      const ok = await invokeBackend('x:check-login');
+      setXLoggedIn(!!ok);
+      setToast({ message: ok ? 'X(Twitter)にログイン済みです' : 'X(Twitter)にログインしていません', type: ok ? 'success' : 'error' });
+    } catch (err) {
+      setXLoggedIn(false);
+      setError('X確認失敗: ' + err.message);
+    }
+  };
+
   const handleCreate = async (e) => {
     e.preventDefault();
     if (!groupId || !title || !text || !scheduledAt) return;
@@ -320,7 +362,11 @@ export default function Dashboard() {
         scheduledAt: new Date(scheduledAt).toISOString(),
         sendNotification: notification,
         recurrence,
-        status: isRecurring ? 'recurring' : 'pending'
+        status: isRecurring ? 'recurring' : 'pending',
+        imageDataUrl: imageDataUrl || null,
+        imageName: imageName || null,
+        postToX,
+        xText: postToX ? (xText || `${title}\n\n${text}`) : null,
       });
 
       if (res) { // res is the new post object
@@ -329,6 +375,10 @@ export default function Dashboard() {
         setScheduledAt('');
         setIsRecurring(false);
         setRecurrenceDays([]);
+        setImageDataUrl('');
+        setImageName('');
+        setPostToX(false);
+        setXText('');
         fetchPosts();
         setToast({ message: '投稿をスケジュールしました！', type: 'success' });
       }
@@ -372,6 +422,10 @@ export default function Dashboard() {
     setText(post.text);
     setNotification(post.sendNotification || false);
     setScheduledAt('');
+    setImageDataUrl(post.imageDataUrl || '');
+    setImageName(post.imageName || '');
+    setPostToX(!!post.postToX);
+    setXText(post.xText || '');
 
     setError('');
   };
@@ -394,6 +448,10 @@ export default function Dashboard() {
     setText(post.text);
     setNotification(post.sendNotification || false);
     setScheduledAt(''); // Reset time for new schedule
+    setImageDataUrl(post.imageDataUrl || '');
+    setImageName(post.imageName || '');
+    setPostToX(!!post.postToX);
+    setXText(post.xText || '');
 
     // Handle Recurrence
     if (post.recurrence) {
@@ -664,6 +722,47 @@ export default function Dashboard() {
               </div>
 
               <div className={styles.formGroup}>
+                <label className={styles.label}>Image (Optional, PNG/JPG, ≤5MB)</label>
+                <input
+                  type="file"
+                  accept="image/png,image/jpeg,image/gif"
+                  onChange={handleImageChange}
+                  style={{ color: '#e2e8f0', fontSize: '0.9rem' }}
+                />
+                <div style={{ fontSize: '0.7rem', color: '#d69e2e', marginTop: '0.25rem' }}>
+                  ※ VRChat側の画像添付は VRC+ サブスクライブ必須で、最低 512×512px 程度必要です。条件外なら画像なしで投稿継続し、X同時投稿には影響しません。
+                </div>
+                {imageDataUrl && (
+                  <div style={{ marginTop: '0.5rem', display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
+                    <img
+                      src={imageDataUrl}
+                      alt="preview"
+                      style={{ maxWidth: '120px', maxHeight: '80px', borderRadius: '4px', border: '1px solid #4a5568' }}
+                    />
+                    <div style={{ flex: 1 }}>
+                      <div style={{ color: '#a0aec0', fontSize: '0.8rem', wordBreak: 'break-all' }}>{imageName}</div>
+                      <button
+                        type="button"
+                        onClick={() => { setImageDataUrl(''); setImageName(''); }}
+                        style={{
+                          marginTop: '0.3rem',
+                          background: '#4a5568',
+                          color: '#fff',
+                          border: 'none',
+                          borderRadius: '3px',
+                          padding: '0.2rem 0.6rem',
+                          fontSize: '0.75rem',
+                          cursor: 'pointer'
+                        }}
+                      >
+                        画像を削除
+                      </button>
+                    </div>
+                  </div>
+                )}
+              </div>
+
+              <div className={styles.formGroup}>
                 <label className={styles.label}>Start Time (First Execution)</label>
                 <input
                   type="datetime-local"
@@ -743,6 +842,58 @@ export default function Dashboard() {
                 <label htmlFor="noti" style={{ marginBottom: 0, color: '#fff' }}>Send Notification to Group</label>
               </div>
 
+              <div className={styles.formGroup}>
+                <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center', marginBottom: '0.5rem' }}>
+                  <input
+                    type="checkbox"
+                    id="postX"
+                    checked={postToX}
+                    onChange={e => setPostToX(e.target.checked)}
+                  />
+                  <label htmlFor="postX" style={{ marginBottom: 0, color: '#fff', fontWeight: 'bold' }}>X(Twitter)にも同時投稿</label>
+                  <span
+                    onClick={handleCheckXLogin}
+                    style={{
+                      marginLeft: 'auto',
+                      color: xLoggedIn === true ? '#48bb78' : xLoggedIn === false ? '#f56565' : '#63b3ed',
+                      cursor: 'pointer',
+                      textDecoration: 'underline',
+                      fontSize: '0.8rem',
+                    }}
+                    title="X(Twitter)へのログイン状態を確認"
+                  >
+                    {xLoggedIn === true ? '✓ ログイン済み' : xLoggedIn === false ? '✕ 未ログイン' : 'X ログイン確認'}
+                  </span>
+                </div>
+
+                {postToX && (
+                  <div style={{ marginLeft: '1.5rem', padding: '0.5rem', background: '#2d3748', borderRadius: '4px' }}>
+                    <label className={styles.label} style={{ fontSize: '0.9rem' }}>
+                      Xポスト本文（空欄ならTitle+Messageを使用、280字以内）
+                    </label>
+                    <textarea
+                      className={styles.textarea}
+                      style={{ fontSize: '0.9rem', minHeight: '60px' }}
+                      value={xText}
+                      onChange={e => setXText(e.target.value)}
+                      maxLength={280}
+                      placeholder={`${title}\n\n${text}`.slice(0, 280)}
+                    />
+                    <div style={{ fontSize: '0.75rem', color: '#a0aec0', textAlign: 'right' }}>
+                      {(xText || `${title}\n\n${text}`).length} / 280
+                    </div>
+                    {imageDataUrl && (
+                      <div style={{ fontSize: '0.75rem', color: '#90cdf4' }}>
+                        ↑ アップロードした画像も同時に投稿します
+                      </div>
+                    )}
+                    <div style={{ fontSize: '0.75rem', color: '#d69e2e', marginTop: '0.3rem' }}>
+                      ※ ブラウザでX(Twitter)にログイン済みであることが必要です
+                    </div>
+                  </div>
+                )}
+              </div>
+
               <button type="submit" className={styles.button}>Schedule Post</button>
             </form>
           </section>
@@ -775,6 +926,8 @@ export default function Dashboard() {
                   <div className={styles.postInfo}>
                     <div className={styles.postTitle}>
                       {post.status === 'recurring' && <span style={{ fontSize: '0.8rem', background: '#3182ce', padding: '2px 6px', borderRadius: '4px', marginRight: '6px' }}>Repeat</span>}
+                      {post.imageDataUrl && <span style={{ fontSize: '0.75rem', background: '#48bb78', padding: '2px 6px', borderRadius: '4px', marginRight: '6px' }}>IMG</span>}
+                      {post.postToX && <span style={{ fontSize: '0.75rem', background: '#1da1f2', padding: '2px 6px', borderRadius: '4px', marginRight: '6px' }}>X</span>}
                       {post.title}
                     </div>
                     <div className={styles.postMeta}>
@@ -783,6 +936,16 @@ export default function Dashboard() {
                         <div style={{ color: '#90cdf4', fontSize: '0.85rem', marginTop: '2px' }}>
                           ↻ {post.recurrence.type.charAt(0).toUpperCase() + post.recurrence.type.slice(1)}
                           {post.recurrence.type === 'weekly' && post.recurrence.days && ` (${post.recurrence.days.map(d => ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'][d]).join(', ')})`}
+                        </div>
+                      )}
+                      {post.vrcImageError && (
+                        <div style={{ color: '#fc8181', fontSize: '0.8rem', marginTop: '2px' }}>
+                          画像添付失敗: {post.vrcImageError}
+                        </div>
+                      )}
+                      {post.xError && (
+                        <div style={{ color: '#fc8181', fontSize: '0.8rem', marginTop: '2px' }}>
+                          X投稿失敗: {post.xError}
                         </div>
                       )}
                     </div>

--- a/public/background/api.js
+++ b/public/background/api.js
@@ -18,11 +18,14 @@ async function apiRequest(endpoint, options = {}) {
     const maxRetries = 3;
     let backoff = 2000;
 
+    const isMultipart = options.body instanceof FormData;
+    const baseHeaders = isMultipart ? {} : { 'Content-Type': 'application/json' };
+
     for (let attempt = 0; attempt <= maxRetries; attempt++) {
         const res = await fetch(url, {
             ...options,
             headers: {
-                'Content-Type': 'application/json',
+                ...baseHeaders,
                 ...options.headers,
             },
             credentials: 'include',
@@ -396,11 +399,34 @@ export const api = {
         return getGroupDetail(groupId);
     },
 
-    async createGroupPost(groupId, title, text, sendNotification = false) {
+    async createGroupPost(groupId, title, text, sendNotification = false, imageId = null) {
+        const body = { title, text, sendNotification };
+        if (imageId) body.imageId = imageId;
         const res = await apiRequest(`/groups/${groupId}/posts`, {
             method: 'POST',
-            body: JSON.stringify({ title, text, sendNotification })
+            body: JSON.stringify(body)
         });
         return res.json();
+    },
+
+    async uploadImage(blob, filename = 'image.png', tag = 'gallery') {
+        const form = new FormData();
+        form.append('file', blob, filename);
+        form.append('tag', tag);
+        const res = await apiRequest('/file/image', {
+            method: 'POST',
+            body: form,
+        });
+        const data = await res.json();
+        if (!res.ok || !data.id) {
+            const msg = data.error?.message || `Image upload failed (${res.status})`;
+            const isPermission = res.status === 403 || /permission/i.test(msg);
+            const err = new Error(isPermission
+                ? `VRChatに画像をアップロードできません。VRC+ サブスクライブが必要です（${msg.replace(/^"|"$/g, '')}）`
+                : msg);
+            err.isPermission = isPermission;
+            throw err;
+        }
+        return data.id;
     }
 };

--- a/public/background/background.js
+++ b/public/background/background.js
@@ -2,6 +2,12 @@
 import { api } from './api.js';
 import { storage } from './storage.js';
 import { scheduler } from './scheduler.js';
+import { xApi } from './x-api.js';
+
+async function dataUrlToBlob(dataUrl) {
+    const res = await fetch(dataUrl);
+    return res.blob();
+}
 
 chrome.runtime.onInstalled.addListener(() => {
     console.log('VRChat Group Scheduler Extension Installed');
@@ -31,18 +37,51 @@ chrome.alarms.onAlarm.addListener(async (alarm) => {
     const post = posts[postIndex];
 
     try {
-        const result = await api.createGroupPost(post.groupId, post.title, post.text, post.sendNotification);
+        let imageId = null;
+        let vrcImageError = null;
+        if (post.imageDataUrl) {
+            try {
+                const blob = await dataUrlToBlob(post.imageDataUrl);
+                const filename = post.imageName || 'image.png';
+                imageId = await api.uploadImage(blob, filename, 'gallery');
+            } catch (uploadErr) {
+                vrcImageError = uploadErr.message;
+                console.warn('VRChat image upload failed, posting without image:', uploadErr);
+            }
+        }
+
+        const result = await api.createGroupPost(post.groupId, post.title, post.text, post.sendNotification, imageId);
         console.log('Post successful:', result);
 
-        // Update post status
-        posts[postIndex].status = 'completed';
+        let xResultOk = true;
+        let xError = null;
+        if (post.postToX) {
+            try {
+                const xText = post.xText || `${post.title}\n\n${post.text}`;
+                await xApi.post(xText, post.imageDataUrl || null);
+            } catch (xErr) {
+                xResultOk = false;
+                xError = xErr.message;
+                console.error('X(Twitter) post failed:', xErr);
+            }
+        }
+
+        const fullySuccess = xResultOk && !vrcImageError;
+        posts[postIndex].status = fullySuccess ? 'completed' : 'partial';
+        if (xError) posts[postIndex].xError = xError;
+        if (vrcImageError) posts[postIndex].vrcImageError = vrcImageError;
         await storage.set({ posts });
 
+        const issues = [];
+        if (vrcImageError) issues.push(`画像添付失敗`);
+        if (xError) issues.push(`X投稿失敗`);
         chrome.notifications.create({
             type: 'basic',
             iconUrl: chrome.runtime.getURL('icons/icon128.png'),
-            title: 'VRChat Group Scheduled Post',
-            message: `Successfully posted to group: ${post.groupName || post.groupId}`
+            title: fullySuccess ? 'VRChat Group Scheduled Post' : `投稿完了（${issues.join(' / ')}）`,
+            message: fullySuccess
+                ? `Successfully posted to group: ${post.groupName || post.groupId}`
+                : `VRChat投稿はOK。${vrcImageError ? '画像: ' + vrcImageError + '. ' : ''}${xError ? 'X: ' + xError : ''}`
         });
 
     } catch (error) {
@@ -106,6 +145,12 @@ async function handleApiCall({ action, params }) {
             return api.refreshUserGroups(params.userId);
         case 'getGroup':
             return api.getGroup(params.groupId);
+        case 'xCheckLogin':
+            return xApi.checkLogin();
+        case 'xPostNow': {
+            const { text, imageDataUrl } = params || {};
+            return xApi.post(text, imageDataUrl || null);
+        }
         default:
             throw new Error(`Unknown action: ${action}`);
     }

--- a/public/background/x-api.js
+++ b/public/background/x-api.js
@@ -1,0 +1,262 @@
+// background/x-api.js
+// X(Twitter) posting via browser cookie session.
+// Uses the public web bearer token + ct0 (CSRF) cookie from x.com,
+// then chunk-uploads media to upload.twitter.com and creates a tweet
+// via the GraphQL CreateTweet endpoint.
+
+const X_BEARER = 'AAAAAAAAAAAAAAAAAAAAANRILgAAAAAAnNwIzUejRCOuH5E6I8xnZz4puTs%3D1Zv7ttfk8LF81IUq16cHjhLTvJu4FA33AGWWjCpTnA';
+const X_API_BASE = 'https://api.x.com';
+const X_UPLOAD_BASE = 'https://upload.x.com/i/media/upload.json';
+const CREATE_TWEET_QUERY_ID = 'oB-5XsHNAbjvARJEc8CZFw';
+
+async function getCsrfToken() {
+    return new Promise((resolve, reject) => {
+        chrome.cookies.get({ url: 'https://x.com', name: 'ct0' }, (cookie) => {
+            if (cookie?.value) return resolve(cookie.value);
+            chrome.cookies.get({ url: 'https://twitter.com', name: 'ct0' }, (cookie2) => {
+                if (cookie2?.value) return resolve(cookie2.value);
+                reject(new Error('X(Twitter)のログインCookie(ct0)が見つかりません。ブラウザでログインしてください。'));
+            });
+        });
+    });
+}
+
+async function getAuthToken() {
+    return new Promise((resolve, reject) => {
+        chrome.cookies.get({ url: 'https://x.com', name: 'auth_token' }, (cookie) => {
+            if (cookie?.value) return resolve(cookie.value);
+            chrome.cookies.get({ url: 'https://twitter.com', name: 'auth_token' }, (cookie2) => {
+                if (cookie2?.value) return resolve(cookie2.value);
+                reject(new Error('X(Twitter)にログインしていません。'));
+            });
+        });
+    });
+}
+
+// Read all relevant cookies and build a Cookie header value.
+// SameSite=Lax cookies aren't sent on cross-site POST from extension SW, so we
+// inject them via declarativeNetRequest header rules.
+async function buildCookieHeader() {
+    const fromX = await new Promise(r => chrome.cookies.getAll({ domain: '.x.com' }, c => r(c || [])));
+    const fromTwitter = await new Promise(r => chrome.cookies.getAll({ domain: '.twitter.com' }, c => r(c || [])));
+    const seen = new Set();
+    const parts = [];
+    for (const c of [...fromX, ...fromTwitter]) {
+        if (seen.has(c.name)) continue;
+        seen.add(c.name);
+        parts.push(`${c.name}=${c.value}`);
+    }
+    return parts.join('; ');
+}
+
+const HEADER_RULE_ID = 1009;
+
+async function installHeaderRule() {
+    const cookieValue = await buildCookieHeader();
+    if (!cookieValue) throw new Error('X(Twitter)のCookieが取得できません。ログイン状態を確認してください。');
+
+    await chrome.declarativeNetRequest.updateSessionRules({
+        removeRuleIds: [HEADER_RULE_ID],
+        addRules: [{
+            id: HEADER_RULE_ID,
+            priority: 1,
+            action: {
+                type: 'modifyHeaders',
+                requestHeaders: [
+                    { header: 'cookie', operation: 'set', value: cookieValue },
+                    { header: 'origin', operation: 'set', value: 'https://x.com' },
+                    { header: 'referer', operation: 'set', value: 'https://x.com/home' },
+                ],
+            },
+            condition: {
+                requestDomains: ['api.x.com', 'upload.x.com', 'x.com'],
+                resourceTypes: ['xmlhttprequest'],
+            },
+        }],
+    });
+}
+
+async function uninstallHeaderRule() {
+    try {
+        await chrome.declarativeNetRequest.updateSessionRules({ removeRuleIds: [HEADER_RULE_ID] });
+    } catch (e) {
+        console.warn('Failed to remove X header rule:', e);
+    }
+}
+
+async function withXHeaders(fn) {
+    await installHeaderRule();
+    try {
+        return await fn();
+    } finally {
+        await uninstallHeaderRule();
+    }
+}
+
+function baseHeaders(csrf) {
+    return {
+        'authorization': `Bearer ${X_BEARER}`,
+        'x-csrf-token': csrf,
+        'x-twitter-auth-type': 'OAuth2Session',
+        'x-twitter-active-user': 'yes',
+        'x-twitter-client-language': 'ja',
+    };
+}
+
+async function xFetch(url, options, csrf) {
+    const res = await fetch(url, {
+        ...options,
+        credentials: 'include',
+        headers: {
+            ...baseHeaders(csrf),
+            ...(options.headers || {}),
+        },
+    });
+    if (!res.ok) {
+        const text = await res.text().catch(() => '');
+        throw new Error(`X API ${res.status}: ${text.slice(0, 200)}`);
+    }
+    return res;
+}
+
+async function uploadMediaChunked(blob, mimeType, csrf) {
+    const totalBytes = blob.size;
+
+    // INIT
+    const initForm = new URLSearchParams();
+    initForm.append('command', 'INIT');
+    initForm.append('total_bytes', String(totalBytes));
+    initForm.append('media_type', mimeType);
+    initForm.append('media_category', 'tweet_image');
+
+    const initRes = await xFetch(X_UPLOAD_BASE, {
+        method: 'POST',
+        body: initForm,
+        headers: { 'content-type': 'application/x-www-form-urlencoded' },
+    }, csrf);
+    const initData = await initRes.json();
+    const mediaId = initData.media_id_string;
+    if (!mediaId) throw new Error('X media INIT failed: no media_id');
+
+    // APPEND (single chunk for simplicity; X allows up to ~5MB per chunk)
+    const CHUNK = 4 * 1024 * 1024;
+    let segment = 0;
+    for (let offset = 0; offset < totalBytes; offset += CHUNK) {
+        const slice = blob.slice(offset, Math.min(offset + CHUNK, totalBytes));
+        const form = new FormData();
+        form.append('command', 'APPEND');
+        form.append('media_id', mediaId);
+        form.append('segment_index', String(segment));
+        form.append('media', slice);
+        await xFetch(X_UPLOAD_BASE, { method: 'POST', body: form }, csrf);
+        segment++;
+    }
+
+    // FINALIZE
+    const finalizeForm = new URLSearchParams();
+    finalizeForm.append('command', 'FINALIZE');
+    finalizeForm.append('media_id', mediaId);
+    const finalizeRes = await xFetch(X_UPLOAD_BASE, {
+        method: 'POST',
+        body: finalizeForm,
+        headers: { 'content-type': 'application/x-www-form-urlencoded' },
+    }, csrf);
+    const finalizeData = await finalizeRes.json();
+
+    // STATUS polling if processing
+    if (finalizeData.processing_info) {
+        let info = finalizeData.processing_info;
+        while (info && (info.state === 'pending' || info.state === 'in_progress')) {
+            await new Promise(r => setTimeout(r, (info.check_after_secs || 1) * 1000));
+            const statusUrl = `${X_UPLOAD_BASE}?command=STATUS&media_id=${mediaId}`;
+            const statusRes = await xFetch(statusUrl, { method: 'GET' }, csrf);
+            const statusData = await statusRes.json();
+            info = statusData.processing_info;
+            if (info?.state === 'failed') {
+                throw new Error(`X media processing failed: ${info.error?.message || 'unknown'}`);
+            }
+        }
+    }
+
+    return mediaId;
+}
+
+async function createTweet(text, mediaIds, csrf) {
+    const variables = {
+        tweet_text: text,
+        dark_request: false,
+        media: {
+            media_entities: (mediaIds || []).map(id => ({ media_id: id, tagged_users: [] })),
+            possibly_sensitive: false,
+        },
+        semantic_annotation_ids: [],
+    };
+
+    const features = {
+        communities_web_enable_tweet_community_results_fetch: true,
+        c9s_tweet_anatomy_moderator_badge_enabled: true,
+        responsive_web_grok_analyze_button_fetch_trends_enabled: false,
+        responsive_web_grok_analyze_post_followups_enabled: true,
+        responsive_web_jetfuel_frame: false,
+        responsive_web_grok_share_attachment_enabled: true,
+        responsive_web_edit_tweet_api_enabled: true,
+        graphql_is_translatable_rweb_tweet_is_translatable_enabled: true,
+        view_counts_everywhere_api_enabled: true,
+        longform_notetweets_consumption_enabled: true,
+        responsive_web_twitter_article_tweet_consumption_enabled: true,
+        tweet_awards_web_tipping_enabled: false,
+        creator_subscriptions_quote_tweet_preview_enabled: false,
+        longform_notetweets_rich_text_read_enabled: true,
+        longform_notetweets_inline_media_enabled: true,
+        profile_label_improvements_pcf_label_in_post_enabled: true,
+        rweb_tipjar_consumption_enabled: true,
+        responsive_web_graphql_exclude_directive_enabled: true,
+        verified_phone_label_enabled: false,
+        articles_preview_enabled: true,
+        responsive_web_graphql_skip_user_profile_image_extensions_enabled: false,
+        responsive_web_graphql_timeline_navigation_enabled: true,
+        responsive_web_enhance_cards_enabled: false,
+        standardized_nudges_misinfo: true,
+        tweet_with_visibility_results_prefer_gql_limited_actions_policy_enabled: true,
+        rweb_video_timestamps_enabled: true,
+        freedom_of_speech_not_reach_fetch_enabled: true,
+    };
+
+    const url = `${X_API_BASE}/graphql/${CREATE_TWEET_QUERY_ID}/CreateTweet`;
+    const res = await xFetch(url, {
+        method: 'POST',
+        body: JSON.stringify({ variables, features, queryId: CREATE_TWEET_QUERY_ID }),
+        headers: { 'content-type': 'application/json' },
+    }, csrf);
+    return res.json();
+}
+
+export const xApi = {
+    async checkLogin() {
+        try {
+            await getAuthToken();
+            await getCsrfToken();
+            return true;
+        } catch {
+            return false;
+        }
+    },
+
+    async post(text, imageDataUrl = null) {
+        const csrf = await getCsrfToken();
+        await getAuthToken();
+
+        return withXHeaders(async () => {
+            const mediaIds = [];
+            if (imageDataUrl) {
+                const fetchRes = await fetch(imageDataUrl);
+                const blob = await fetchRes.blob();
+                const mimeType = blob.type || 'image/png';
+                const mediaId = await uploadMediaChunked(blob, mimeType, csrf);
+                mediaIds.push(mediaId);
+            }
+
+            return createTweet(text || '', mediaIds, csrf);
+        });
+    },
+};

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "VRChat Group Notify Scheduler",
-    "version": "2.0.1",
+    "version": "2.1.0.1",
     "description": "Schedule and automate group announcements on VRChat.",
     "permissions": [
         "storage",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -5,13 +5,18 @@
     "description": "Schedule and automate group announcements on VRChat.",
     "permissions": [
         "storage",
+        "unlimitedStorage",
         "alarms",
         "cookies",
-        "notifications"
+        "notifications",
+        "declarativeNetRequestWithHostAccess"
     ],
     "host_permissions": [
         "https://api.vrchat.cloud/*",
-        "https://vrchat.com/*"
+        "https://vrchat.com/*",
+        "https://api.x.com/*",
+        "https://x.com/*",
+        "https://upload.x.com/*"
     ],
     "background": {
         "service_worker": "background/background.js",

--- a/utils/extension-api.js
+++ b/utils/extension-api.js
@@ -71,6 +71,15 @@ export const invokeBackend = async (action, payload = {}) => {
             case 'app:get-version':
                 return resolve(chrome.runtime.getManifest().version);
 
+            case 'x:check-login':
+                type = 'API_CALL';
+                payload = { action: 'xCheckLogin' };
+                break;
+            case 'x:post-now':
+                type = 'API_CALL';
+                payload = { action: 'xPostNow', params: payload };
+                break;
+
             // Ignore updater actions
             case 'updater:get-settings':
             case 'updater:save-settings':


### PR DESCRIPTION
## Summary
- VRChatグループ投稿に**画像添付**を実装（VRC+ サブスクライブ必須、`/file/image` の `gallery` タグ）
- **X(Twitter)同時投稿**を実装（Cookieセッション+declarativeNetRequestでヘッダ注入、画像付き対応）
- 既存のCreateTweet/Media UploadエンドポイントをX.com系（`api.x.com` / `upload.x.com`）に統一
- UI: 画像選択欄、X同時投稿チェックボックス（280字本文編集）、Xログイン確認、エラー表示

## 動作
- 画像なし投稿: VRChat ✓
- 画像あり投稿（VRC+あり）: VRChat ✓画像付き + Xあり時もX ✓画像付き
- 画像あり投稿（VRC+なし）: VRChat ✓画像なし（明示エラー記録）+ X ✓画像付き
- 画像はChromeストレージに base64 保存（`unlimitedStorage`権限）

## 追加した権限
| 権限 | 用途 |
|---|---|
| `unlimitedStorage` | 画像 base64 を含む投稿の保存（既定 10MB 超過防止） |
| `declarativeNetRequestWithHostAccess` | X API への `Cookie`/`Origin`/`Referer` 注入（SameSite=Lax 対応） |
| `host_permissions: x.com/api.x.com/upload.x.com` | X API へのアクセス |

## セキュリティレビュー
- Bearer Token は X 公式 web クライアントの**公開**トークン（秘密情報ではない）
- Cookie読み取りは host_permissions 宣言済みドメインのみ
- declarativeNetRequest セッションルールは投稿処理中のみ存在し、try/finally で確実に解除
- ユーザー入力は全て JSON body で送信、HTML interpolation なし
- 第三者へのデータ送信なし
- 詳細は [PR会話のレビュー結果](#) を参照

## Test plan
- [ ] 拡張機能を**削除 → out/を再読み込み**して新権限を承認
- [ ] X(Twitter)に**ログイン状態**でchrome起動
- [ ] X ログイン確認リンクで「✓ ログイン済み」が出ること
- [ ] テキストのみのスケジュール投稿が動作する（既存機能）
- [ ] X同時投稿チェックON＋画像なし → 両方投稿される
- [ ] 画像（512×512以上のPNG/JPG）を添付 → VRChat（VRC+ありで画像付き）+ X（画像付き）に投稿される
- [ ] エラー時の通知メッセージとUIエラー表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)